### PR TITLE
use latest version by default in migration

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,14 +8,12 @@ on: [pull_request]
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-
       - name: Check out repository
         uses: actions/checkout@v3
 
@@ -25,13 +23,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
-        uses: snok/install-poetry@v1.3
+        run: |
+          pip install poetry
+          poetry self add "poetry-dynamic-versioning[plugin]"
 
       - name: Install dependencies
-        run: poetry install --no-interaction --no-root
-
-      - name: Install project
-        run: poetry install --no-interaction
+        run: poetry install
 
       - name: Run test suite
         run: make test

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ test-schema:
 	$(RUN) gen-project ${GEN_PARGS} -d tmp $(SOURCE_SCHEMA_PATH)
 
 test-python:
-	$(RUN) python -m unittest discover
+	$(RUN) pytest -vs
 
 lint:
 	$(RUN) linkml-lint $(SOURCE_SCHEMA_PATH)

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,3 +1,4 @@
+from opencloning_linkml._version import __version__
 import unittest
 from opencloning_linkml.migrations import migrate
 from opencloning_linkml.migrations.migrate import main as migrate_script_main
@@ -96,6 +97,12 @@ class TestMigration(unittest.TestCase):
         self.assertEqual(cs.sources[0].assembly[0].left_location, "1..100")
         self.assertEqual(cs.sources[1].coordinates, "1..100")
 
+    def test_migration_to_latest(self):
+        with open(os.path.join(test_folder, "migration/v0.2.6.1/homologous_recombination.json"), "r") as f:
+            data = json.load(f)
+        migrated_data = migrate(data, None)
+        self.assertEqual(migrated_data["schema_version"], __version__)
+
     def test_migration_script(self):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -107,11 +114,11 @@ class TestMigration(unittest.TestCase):
             with patch("builtins.print") as mock_print:
                 migrate_script_main(test_file, backup=True, target_version=None)
                 mock_print.assert_any_call(f"Original file backed up as {test_file.replace('.json', '_backup.json')}")
-                mock_print.assert_any_call(f"Migrated {test_file} to version 0.2.9")
+                mock_print.assert_any_call(f"Migrated {test_file} to version {__version__}")
 
             with open(test_file, "r") as f:
                 data = json.load(f)
-            self.assertEqual(data["schema_version"], "0.2.9")
+            self.assertEqual(data["schema_version"], __version__)
             self.assertEqual(data["backend_version"], None)
             self.assertEqual(data["frontend_version"], None)
 


### PR DESCRIPTION
when migrating, use latest version by default rather than latest migration version